### PR TITLE
Remove ensure to work with newish versions of concat::fragment.

### DIFF
--- a/manifests/contactgroup.pp
+++ b/manifests/contactgroup.pp
@@ -19,6 +19,5 @@ define nagioscfg::contactgroup($cgalias = undef, $ensure = 'present', $members =
     content => template('nagioscfg/contactgroup.erb'),
     order   => '30',
     notify  => Service["${nagioscfg::service}"],
-    ensure  => $ensure
   }
 }

--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -2,7 +2,6 @@ include stdlib
 include concat
 # Use a template to create a host config
 define nagioscfg::host(
-  $ensure                              = 'present',
   $single_ip                           = false,
   $action_url                          = undef,
   $sort_alphabetically                 = false,
@@ -33,7 +32,6 @@ define nagioscfg::host(
   }
 
   concat::fragment {"${nagioscfg::config}_host_${name}":
-    ensure  => $ensure,
     target  => "${nagioscfg::cfgdir}/${nagioscfg::config}_hosts.cfg",
     content => template('nagioscfg/host.erb'),
     order   => '30',

--- a/manifests/hostgroup.pp
+++ b/manifests/hostgroup.pp
@@ -1,7 +1,7 @@
 include stdlib
 include concat
 
-define nagioscfg::hostgroup($hgalias = undef, $ensure = 'present', $members = undef) {
+define nagioscfg::hostgroup($hgalias = undef, $members = undef) {
   $hostgroup_alias = $hgalias ? {
     undef   => $name,
     default => $hgalias
@@ -19,6 +19,5 @@ define nagioscfg::hostgroup($hgalias = undef, $ensure = 'present', $members = un
     content => template('nagioscfg/hostgroup.erb'),
     order   => '30',
     notify  => Service["${nagioscfg::service}"],
-    ensure  => $ensure
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,8 +1,7 @@
 include stdlib
 include concat
 
-define nagioscfg::service($ensure = 'present',
-                          $action_url = undef,
+define nagioscfg::service($action_url = undef,
                           $hostgroup_name = undef,
                           $host_name = undef,
                           $description = undef,
@@ -37,6 +36,5 @@ define nagioscfg::service($ensure = 'present',
     content => template('nagioscfg/service.erb'),
     order   => '30',
     notify  => Service["${nagioscfg::service}"],
-    ensure  => $ensure
   }
 }

--- a/manifests/servicegroup.pp
+++ b/manifests/servicegroup.pp
@@ -1,7 +1,7 @@
 include stdlib
 include concat
 
-define nagioscfg::servicegroup($sgalias = undef, $ensure = 'present', $members = undef) {
+define nagioscfg::servicegroup($sgalias = undef, $members = undef) {
   $servicegroup_alias = $sgalias ? {
     undef   => $name,
     default => $sgalias
@@ -15,6 +15,5 @@ define nagioscfg::servicegroup($sgalias = undef, $ensure = 'present', $members =
     content => template('nagioscfg/servicegroup.erb'),
     order   => '30',
     notify  => Service["${nagioscfg::service}"],
-    ensure  => $ensure
   }
 }


### PR DESCRIPTION
Nagioscfg crashes with ensure variable in the new concat::fragment packaged by debian.
`Error: Evaluation Error: Error while evaluating a Resource Statement, Concat::Fragment[naemon_monitor_contactgroup_alerts]: has no parameter named 'ensure' (file: /etc/puppet/cosmos-modules/nagioscfg/manifests/contactgroup.pp, line: 17)`

This fix removes the ensure variable where it was used. Tested on monitor-1.test.swamid.se