### PR TITLE
Make the 'all group' configurable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -119,9 +119,18 @@ class nagioscfg(
       unless $hostname in $exclude_hosts {
         notify {"generating ${hostname}": }
         if $custom_host_fields == undef {
-          nagioscfg::host {$hostname: single_ip => $single_ip, sort_alphabetically => $sort_alphabetically, default_host_group => $default_host_group}
+          nagioscfg::host { $hostname:
+            single_ip           => $single_ip,
+            sort_alphabetically => $sort_alphabetically,
+            default_host_group  => $default_host_group
+          }
         } elsif $custom_host_fields != undef {
-          nagioscfg::host {$hostname: single_ip => $single_ip, sort_alphabetically => $sort_alphabetically, default_host_group => $default_host_group, custom_host_fields => $custom_host_fields[$hostname] }
+          nagioscfg::host { $hostname:
+            single_ip           => $single_ip,
+            sort_alphabetically => $sort_alphabetically,
+            default_host_group  => $default_host_group,
+            custom_host_fields  => $custom_host_fields[$hostname]
+          }
         }
       }
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,6 +14,7 @@ class nagioscfg(
   Optional[String] $default_host_group = undef,
   Optional[Hash] $custom_host_fields = undef,
   Hash $additional_entities = {},
+  Optional[String] $all_group = 'all',
 )
 {
   if $manage_package {
@@ -113,8 +114,8 @@ class nagioscfg(
     order   => '10',
   }
 
-  if has_key($hostgroups,'all') {
-    each($hostgroups['all']) |$hostname| {
+  if has_key($hostgroups, $all_group) {
+    each($hostgroups[$all_group]) |$hostname| {
       unless $hostname in $exclude_hosts {
         notify {"generating ${hostname}": }
         if $custom_host_fields == undef {
@@ -127,7 +128,7 @@ class nagioscfg(
   }
 
   each($hostgroups) |$hgn, $members| {
-    if $hgn != 'all' {
+    if !($hgn in [$all_group, 'all']) {
       $filtered_members = delete($members, $exclude_hosts)
       nagioscfg::hostgroup {$hgn: members => $filtered_members}
     }


### PR DESCRIPTION
This way, you can set the variable `all_group` to whatever you want.

E.g. `all_group = 'test'` will make sure only the serves in the group `test` are included.