### PR TITLE
puppet8 compatibility fixes

### DIFF
--- a/manifests/contactgroup.pp
+++ b/manifests/contactgroup.pp
@@ -4,7 +4,7 @@ define nagioscfg::contactgroup($cgalias = undef, $ensure = 'present', $members =
     undef   => $name,
     default => $cgalias
   }
-  $def_members = has_key($nagioscfg::contactgroups, $name) ? {
+  $def_members = if $name in $nagioscfg::contactgroups ? {
     true  => $nagioscfg::contactgroups[$name],
     false => undef,
   }

--- a/manifests/contactgroup.pp
+++ b/manifests/contactgroup.pp
@@ -4,7 +4,7 @@ define nagioscfg::contactgroup($cgalias = undef, $ensure = 'present', $members =
     undef   => $name,
     default => $cgalias
   }
-  $def_members = (if $name in $nagioscfg::contactgroups) ? {
+  $def_members = $name in $nagioscfg::contactgroups ? {
     true  => $nagioscfg::contactgroups[$name],
     false => undef,
   }

--- a/manifests/contactgroup.pp
+++ b/manifests/contactgroup.pp
@@ -4,7 +4,7 @@ define nagioscfg::contactgroup($cgalias = undef, $ensure = 'present', $members =
     undef   => $name,
     default => $cgalias
   }
-  $def_members = if $name in $nagioscfg::contactgroups ? {
+  $def_members = (if $name in $nagioscfg::contactgroups) ? {
     true  => $nagioscfg::contactgroups[$name],
     false => undef,
   }

--- a/manifests/hostgroup.pp
+++ b/manifests/hostgroup.pp
@@ -4,7 +4,7 @@ define nagioscfg::hostgroup($hgalias = undef, $members = undef) {
     undef   => $name,
     default => $hgalias
   }
-  $def_members = (if $name in $nagioscfg::hostgroups) ? {
+  $def_members = $name in $nagioscfg::hostgroups ? {
     true  => $nagioscfg::hostgroups[$name],
     false => undef,
   }

--- a/manifests/hostgroup.pp
+++ b/manifests/hostgroup.pp
@@ -4,7 +4,7 @@ define nagioscfg::hostgroup($hgalias = undef, $members = undef) {
     undef   => $name,
     default => $hgalias
   }
-  $def_members = has_key($nagioscfg::hostgroups, $name) ? {
+  $def_members = if $name in $nagioscfg::hostgroups ? {
     true  => $nagioscfg::hostgroups[$name],
     false => undef,
   }

--- a/manifests/hostgroup.pp
+++ b/manifests/hostgroup.pp
@@ -4,7 +4,7 @@ define nagioscfg::hostgroup($hgalias = undef, $members = undef) {
     undef   => $name,
     default => $hgalias
   }
-  $def_members = if $name in $nagioscfg::hostgroups ? {
+  $def_members = (if $name in $nagioscfg::hostgroups) ? {
     true  => $nagioscfg::hostgroups[$name],
     false => undef,
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -125,7 +125,7 @@ class nagioscfg(
     order   => '10',
   }
 
-  if has_key($hostgroups, $all_group) {
+  if $all_group in $hostgroups {
     each($hostgroups[$all_group]) |$hostname| {
       unless $hostname in $exclude_hosts {
         notify {"generating ${hostname}": }


### PR DESCRIPTION
The `has_key` syntax is deprecated and does not work in puppet8: 
- https://puppetlabs.github.io/content-and-tooling-team/blog/posts/2023-05-12-deprecation-of-stdlib-functions/
- https://forge.puppet.com/modules/puppetlabs/stdlib/6.0.0/readme#has_key

New syntax inspiration from this post:
- https://stackoverflow.com/questions/74799510/how-to-check-whether-hash-has-a-value-for-the-key-in-puppet