### PR TITLE
Add support for static fqdn -> ip list

### DIFF
--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -10,7 +10,7 @@ define nagioscfg::host(
   Optional[Hash] $ip_override_map = undef,
 ) {
 
-  # Determine static IP list is provided, else fall back to dnsLookup
+  # Determine if a static IP list is provided, else fall back to dnsLookup like before
   if $ip_override_map and $ip_override_map[$name] {
     $unsorted_temp_ip_list = $ip_override_map[$name]
   } else {

--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -1,11 +1,21 @@
 # Use a template to create a host config
+
+# @param ip_override_map  If you for some reason can't rely on dnsLookup, you can use this parameter to provide a fqdn -> IP hash
 define nagioscfg::host(
   $single_ip                           = false,
   $action_url                          = undef,
   $sort_alphabetically                 = false,
   Optional[String] $default_host_group = undef,
   Optional[Hash] $custom_host_fields = undef,
+  Optional[Hash] $ip_override_map = undef,
 ) {
+
+  # Determine static IP list is provided, else fall back to dnsLookup
+  if $ip_override_map and $ip_override_map[$name] {
+    $unsorted_temp_ip_list = $ip_override_map[$name]
+  } else {
+    $unsorted_temp_ip_list = dnsLookup($name)
+  }
   $unsorted_temp_ip_list = dnsLookup($name)
   if $sort_alphabetically {
     $temp_ip_list = sort($unsorted_temp_ip_list)

--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -16,7 +16,6 @@ define nagioscfg::host(
   } else {
     $unsorted_temp_ip_list = dnsLookup($name)
   }
-  $unsorted_temp_ip_list = dnsLookup($name)
   if $sort_alphabetically {
     $temp_ip_list = sort($unsorted_temp_ip_list)
   } else {

--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -7,12 +7,12 @@ define nagioscfg::host(
   $sort_alphabetically                 = false,
   Optional[String] $default_host_group = undef,
   Optional[Hash] $custom_host_fields = undef,
-  Optional[Hash] $ip_override_map = undef,
+  Optional[Array] $ip_override = undef,
 ) {
 
   # Determine if a static IP list is provided, else fall back to dnsLookup like before
-  if $ip_override_map and $ip_override_map[$name] {
-    $unsorted_temp_ip_list = $ip_override_map[$name]
+  if $ip_override {
+    $unsorted_temp_ip_list = $ip_override
   } else {
     $unsorted_temp_ip_list = dnsLookup($name)
   }


### PR DESCRIPTION
Adding support for providing a hash of FQDN to IP mapping.
The use case right now for this is monitoring of servers that can not be resolved by hostname since they are in a domain that is not public.

This is tested on `monitor-vr `and `monitor-netops` and it had no affect on them while not passing the $ip_override_map argument.

Example of a call to `nagioscfg::host`
```
$windows_fqdn_ip_map = {
  'example1.example.com' => ['x.x.x.x'],
  'example2.example.com' => ['y.y.y.y'],
}

$windows_fqdn_ip_map.each |$fqdn, $ip_array| {
  nagioscfg::host { $fqdn:
    ip_override         => $ip_array ,
    single_ip           => true,
    sort_alphabetically => true,
    default_host_group  => 'windows',
  }
}
```
