### PR TITLE
added event_handler_enabled and obsess as optional fields for a service

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -16,6 +16,8 @@ define nagioscfg::service($action_url = undef,
                           $notification_options = undef,
                           $notification_interval = undef,
                           $notifications_enabled = undef,
+                          $event_handler_enabled = undef,
+                          $obsess = undef,
 ) {
   $hostgroup_list = $hostgroup_name ? {
     undef   => undef,

--- a/templates/service.erb
+++ b/templates/service.erb
@@ -18,5 +18,7 @@ define service {
 <% if @notification_interval %>  notification_interval <%= @notification_interval %><% end %>
 <% if @notification_options %>  notification_options <%= @notification_options %><% end %>
 <% if @notifications_enabled %>  notifications_enabled <%= @notifications_enabled %><% end %>
+<% if @event_handler_enabled %>  event_handler_enabled <%= @event_handler_enabled %><% end %>
+<% if @obsess %>  obsess <%= @obsess %><% end %>
   register <%= @register %>
 }


### PR DESCRIPTION
Added 2 new fields for the service object definition:
- obsess and event_handler_enabled.

This can be used to enable/disable those two fields on specific services or types of services. 
Helpful when integrated with Argus so we can nitpick which services shall be forwarded from nagios/naemon.  